### PR TITLE
Map no longer inherits asset

### DIFF
--- a/assets/json/assets.json
+++ b/assets/json/assets.json
@@ -54,7 +54,8 @@
         }
 	},
     "jsons": {
-        "server": "json/server.json"
+        "server": "json/server.json",
+        "map": "json/map.json"
     },
     "sounds": {
         "game": {

--- a/source/RootedApp.cpp
+++ b/source/RootedApp.cpp
@@ -36,7 +36,6 @@ void RootedApp::onStartup() {
     _assets->attach<Texture>(TextureLoader::alloc()->getHook());
     _assets->attach<Sound>(SoundLoader::alloc()->getHook());
     _assets->attach<scene2::SceneNode>(Scene2Loader::alloc()->getHook());
-    _assets->attach<Map>(GenericLoader<Map>::alloc()->getHook());
     _assets->attach<JsonValue>(JsonLoader::alloc()->getHook());
     _assets->attach<WidgetValue>(WidgetLoader::alloc()->getHook());
 
@@ -48,7 +47,6 @@ void RootedApp::onStartup() {
     // Que up the other assets
     AudioEngine::start();
     _assets->loadDirectoryAsync("json/assets.json",nullptr);
-    _assets->loadAsync<Map>("map", "json/map.json", nullptr);
     
     cugl::net::NetworkLayer::start(net::NetworkLayer::Log::INFO);
     

--- a/source/objects/Map.h
+++ b/source/objects/Map.h
@@ -10,7 +10,7 @@
 #include "Farmer.h"
 #include "Wheat.h"
 
-class Map : public Asset {
+class Map {
 private:
     /** references to the baby carrots */
     std::vector<std::shared_ptr<BabyCarrot>> _babies;
@@ -32,6 +32,8 @@ private:
     Vec2 _gravity;
     /** The scale between the physics world and the screen */
     Vec2 _scale;
+    /** Reference to map json */
+    std::shared_ptr<JsonValue> _json;
     /** The AssetManager for the game mode */
     std::shared_ptr<cugl::AssetManager> _assets;
     /** Reference to the physics root of the scene graph */
@@ -52,19 +54,6 @@ public:
     virtual ~Map(void);
 
     /**
-     * Creates a new Map with no source file.
-     *
-     * The source file can be set at any time via the setFile() method. This method
-     * does NOT load the asset.  You must call the load() method to do that.
-     *
-     * @return  an autoreleased level file
-     */
-    static std::shared_ptr<Map> alloc() {
-        std::shared_ptr<Map> result = std::make_shared<Map>();
-        return (result->init("") ? result : nullptr);
-    }
-
-    /**
      * Creates a new Map with the given source file.
      *
      * This method does NOT load the level. You must call the load() method to do that.
@@ -72,10 +61,18 @@ public:
      *
      * @return  an autoreleased level file
      */
-    static std::shared_ptr<Map> alloc(std::string file) {
+    static std::shared_ptr<Map> alloc(const std::shared_ptr<AssetManager> &assets,
+                                      const std::shared_ptr<scene2::SceneNode> &root,
+                                      const std::shared_ptr<cugl::JsonValue> &json) {
         std::shared_ptr<Map> result = std::make_shared<Map>();
-        return (result->init(file) ? result : nullptr);
+        return (result->init(assets, root, json) ? result : nullptr);
     }
+
+    bool init(const std::shared_ptr<AssetManager> &assets,
+              const std::shared_ptr<scene2::SceneNode> &root,
+              const std::shared_ptr<cugl::JsonValue> &json);
+
+    bool populate();
 
 
 #pragma mark -
@@ -97,7 +94,7 @@ public:
      * @retain the wall
      * @return true if the crate was successfully loaded
      */
-    bool loadWall(const std::shared_ptr<JsonValue>& json);
+    bool loadWall(const std::shared_ptr<JsonValue> &json);
 
     /**
      * Loads a single farmer
@@ -110,7 +107,7 @@ public:
      * @retain the farmer
      * @return true if the crate was successfully loaded
      */
-    bool loadFarmer(const std::shared_ptr<JsonValue>& json);
+    bool loadFarmer(const std::shared_ptr<JsonValue> &json);
 
     /**
      * Loads a single carrot
@@ -123,7 +120,7 @@ public:
      * @retain the carrot
      * @return true if the carrot was successfully loaded
      */
-    bool loadCarrot(const std::shared_ptr<JsonValue>& json);
+    bool loadCarrot(const std::shared_ptr<JsonValue> &json);
 
     /**
      * Loads a single baby carrot
@@ -136,7 +133,7 @@ public:
      * @retain the baby carrot
      * @return true if the baby carrot was successfully loaded
      */
-    bool loadBabyCarrot(const std::shared_ptr<JsonValue>& json);
+    bool loadBabyCarrot(const std::shared_ptr<JsonValue> &json);
 
     /**
      * Loads a single wheat
@@ -149,7 +146,7 @@ public:
      * @retain the baby carrot
      * @return true if the baby carrot was successfully loaded
      */
-    bool loadWheat(const std::shared_ptr<JsonValue>& json);
+    bool loadWheat(const std::shared_ptr<JsonValue> &json);
 
     /**
      * Adds the physics object to the physics world and loosely couples it to the scene graph
@@ -249,65 +246,38 @@ public:
 #pragma mark Asset Loading
 
     /**
-     * Loads this game level from the source file
-     *
-     * This load method should NEVER access the AssetManager.  Assets are loaded in
-     * parallel, not in sequence.  If an asset (like a game level) has references to
-     * other assets, then these should be connected later, during scene initialization.
-     *
-     * @param file the name of the source file to load from
-     *
-     * @return true if successfully loaded the asset from a file
-     */
-    virtual bool preload(const std::string file) override;
-
-
-    /**
-     * Loads this game level from a JsonValue containing all data from a source Json file.
-     *
-     * This load method should NEVER access the AssetManager.  Assets are loaded in
-     * parallel, not in sequence.  If an asset (like a game level) has references to
-     * other assets, then these should be connected later, during scene initialization.
-     *
-     * @param json the json loaded from the source file to use when loading this game level
-     *
-     * @return true if successfully loaded the asset from the input JsonValue
-     */
-    virtual bool preload(const std::shared_ptr<cugl::JsonValue> &json) override;
-
-    /**
      * Unloads this game level, releasing all sources
      *
      * This load method should NEVER access the AssetManager.  Assets are loaded and
      * unloaded in parallel, not in sequence.  If an asset (like a game level) has
      * references to other assets, then these should be disconnected earlier.
      */
-    void unload();
+    void dispose();
 
 
 #pragma mark -
 #pragma mark Getters and Setters
 
-    std::vector<std::shared_ptr<BabyCarrot>>& getBabyCarrots() { return _babies; }
+    std::vector<std::shared_ptr<BabyCarrot>> &getBabyCarrots() { return _babies; }
 
-    std::vector<std::shared_ptr<Carrot>>& getCarrots() { return _carrots; }
+    std::vector<std::shared_ptr<Carrot>> &getCarrots() { return _carrots; }
 
-    std::vector<std::shared_ptr<Farmer>>& getFarmers() { return _farmers; }
+    std::vector<std::shared_ptr<Farmer>> &getFarmers() { return _farmers; }
 
-    std::vector<std::shared_ptr<Wheat>>& getWheat() { return _wheat; }
+    std::vector<std::shared_ptr<Wheat>> &getWheat() { return _wheat; }
 
     std::shared_ptr<cugl::physics2::ObstacleWorld> getWorld() { return _world; }
-    
+
     bool isFarmerPlaying() { return _farmerPlaying; }
-    
+
     bool isShowingPlayer() { return _showPlayer; }
 
     void rustleWheats(float amount);
-    
+
     void clearRustling();
 
     void togglePlayer();
-    
+
     void toggleShowPlayer();
 };
 

--- a/source/scenes/GameScene.cpp
+++ b/source/scenes/GameScene.cpp
@@ -126,24 +126,7 @@ bool GameScene::init(const std::shared_ptr<AssetManager> &assets) {
         return false;
     }
 
-    _map = assets->get<Map>("map");
-    if (_map == nullptr) {
-        CULog("Failed to load map");
-        return false;
-    }
-
     _assets = assets;
-
-    // Create the world and attach the listeners.
-    std::shared_ptr<physics2::ObstacleWorld> world = _map->getWorld();
-    activateWorldCollisions(world);
-
-    // IMPORTANT: SCALING MUST BE UNIFORM
-    // This means that we cannot change the aspect ratio of the physics world
-    // Shift to center if a bad fit
-    _scale = dimen.width == SCENE_WIDTH ? dimen.width / world->getBounds().getMaxX() :
-             dimen.height / world->getBounds().getMaxY();
-    _offset = Vec2((dimen.width - SCENE_WIDTH) / 2.0f, (dimen.height - SCENE_HEIGHT) / 2.0f);
     
     _rootnode = scene2::SceneNode::alloc();
     _rootnode->setAnchor(Vec2::ANCHOR_BOTTOM_LEFT);
@@ -173,21 +156,30 @@ bool GameScene::init(const std::shared_ptr<AssetManager> &assets) {
     _losenode->setForeground(LOSE_COLOR);
     setFailure(false);
 
-    _loadnode = scene2::Label::allocWithText(RESET_MESSAGE, _assets->get<Font>(MESSAGE_FONT));
-    _loadnode->setAnchor(Vec2::ANCHOR_CENTER);
-    _loadnode->setPosition(dimen / 2.0f);
-    _loadnode->setForeground(RESET_COLOR);
-    _loadnode->setVisible(false);
-
     addChild(_rootnode);
     addChild(_uinode);
     addChild(_winnode);
-    addChild(_loadnode);
     addChild(_losenode);
 
     _rootnode->setContentSize(Size(SCENE_WIDTH, SCENE_HEIGHT));
-    _map->setAssets(_assets);
-    _map->setRootNode(_rootnode); // Obtains ownership of root.
+    
+    _map = Map::alloc(_assets, _rootnode, assets->get<JsonValue>("map")); // Obtains ownership of root.
+    
+    if (!_map->populate()) {
+        CULog("Failed to populate map");
+        return false;
+    }
+
+    // Create the world and attach the listeners.
+    std::shared_ptr<physics2::ObstacleWorld> world = _map->getWorld();
+    activateWorldCollisions(world);
+
+    // IMPORTANT: SCALING MUST BE UNIFORM
+    // This means that we cannot change the aspect ratio of the physics world
+    // Shift to center if a bad fit
+    _scale = dimen.width == SCENE_WIDTH ? dimen.width / world->getBounds().getMaxX() :
+             dimen.height / world->getBounds().getMaxY();
+    _offset = Vec2((dimen.width - SCENE_WIDTH) / 2.0f, (dimen.height - SCENE_HEIGHT) / 2.0f);
 
     _input = InputController::alloc(getBounds());
     _collision.init(_map);
@@ -243,7 +235,6 @@ void GameScene::dispose() {
         _input = nullptr;
         _rootnode = nullptr;
         _winnode = nullptr;
-        _loadnode = nullptr;
         _uinode = nullptr;
         _winnode = nullptr;
         _losenode = nullptr;
@@ -267,12 +258,23 @@ void GameScene::dispose() {
  * This method disposes of the world and creates a new one.
  */
 void GameScene::reset() {
-    // Unload the level but keep in memory temporarily
-    _assets->unload<Map>("map");
-
     // Load a new level
-    _loadnode->setVisible(true);
-    _assets->load<Map>("map", "json/map.json");
+    _map->clearRootNode();
+    _map->setRootNode(_rootnode);
+    _map->dispose();
+    _map->populate();
+
+    _collision.dispose();
+    _action.dispose();
+
+    activateWorldCollisions(_map->getWorld());
+
+    _collision.init(_map);
+    _action.init(_map, _input);
+
+    _cam.setPosition(_initCamera);
+    _cam.setTarget(_map->getCarrots().at(0));
+
     setComplete(false);
 }
 
@@ -302,34 +304,6 @@ void GameScene::reset() {
 void GameScene::preUpdate(float dt) {
     if (_map == nullptr) {
         return;
-    }
-
-    // Check to see if new level loaded yet
-    if (_loadnode->isVisible()) {
-        if (_assets->complete()) {
-
-            _collision.dispose();
-            _action.dispose();
-            _map = nullptr;
-
-            // Access and initialize level
-            _map = _assets->get<Map>("map");
-            _map->setAssets(_assets);
-            _map->setRootNode(_rootnode); // Obtains ownership of root.
-            _map->showDebug(_debug);
-
-            activateWorldCollisions(_map->getWorld());
-
-            _collision.init(_map);
-            _action.init(_map, _input);
-
-            _cam.setPosition(_initCamera);
-
-            _loadnode->setVisible(false);
-        } else {
-            // Level is not loaded yet; refuse input
-            return;
-        }
     }
 
     _input->update(dt);

--- a/source/scenes/GameScene.h
+++ b/source/scenes/GameScene.h
@@ -47,8 +47,6 @@ protected:
     // VIEW
     /** Reference to the physics root of the scene graph */
     std::shared_ptr<cugl::scene2::SceneNode> _rootnode;
-    /** Reference to the reset message label */
-    std::shared_ptr<cugl::scene2::Label> _loadnode;
     /** Reference to ui root of scene graph */
     std::shared_ptr<cugl::scene2::SceneNode> _uinode;
     /** Reference to the win message label */


### PR DESCRIPTION
Level loading has been reverted back to the more simple JSON loading rather than having map inherit asset. This is because asset loading is not necessary given the simple structure of our maps, and may even be more troublesome to work with once map loading is networked.

Also fixed camera not following player.