### PR TITLE
One rooting spot can only hold one carrot

### DIFF
--- a/source/controllers/ActionController.cpp
+++ b/source/controllers/ActionController.cpp
@@ -136,7 +136,6 @@ void ActionController::postUpdate(float dt) {
         else ++it;
     }
     for(std::shared_ptr<Carrot> c : _map->getCarrots()){
-//        std::cout<<"capture status"<< c->isCaptured() << "\n";
         if(c->isCaptured()){
             c->setSensor(true);
             c->setX(_map->getFarmers().at(0)->getX()-0.5);
@@ -166,8 +165,6 @@ void ActionController::processCaptureEvent(const std::shared_ptr<CaptureEvent>& 
             }
         }
     }
-//    _map->getCarrots().at(0)->setSensor(true);
-//    _map->getCarrots().at(0)->gotCaptured();
 }
 
 void ActionController::processRootEvent(const std::shared_ptr<RootEvent>& event){

--- a/source/controllers/ActionController.cpp
+++ b/source/controllers/ActionController.cpp
@@ -87,19 +87,27 @@ void ActionController::preUpdate(float dt) {
     
     networkQueuePositions();
     
-    if(_input->didRoot() && _map->getFarmers().at(0)->canPlant() && _map->getCharacter()->getUUID() == _map->getFarmers().at(0)->getUUID()){
+    std::shared_ptr<PlantingSpot> plantingSpot = nullptr;
+    for(auto ps : _map->getPlantingSpots()){
+        if(ps->getBelowAvatar()){
+            plantingSpot = ps;
+            break;
+        }
+    }
+    
+    if(_input->didRoot() && _map->getFarmers().at(0)->canPlant() && _map->getCharacter()->getUUID() == _map->getFarmers().at(0)->getUUID() && plantingSpot != nullptr && !plantingSpot->getCarrotPlanted()){
 //        std::cout<<"farmer did the rooting\n";
         _map->getFarmers().at(0)->rootCarrot();
 
         // look through ever carrot to see if it's rooted (invariant is only one carrot has rooted to be true)
         for (auto carrot : _map->getCarrots()) {
             if (carrot->isCaptured()) {
-                _network->pushOutEvent(RootEvent::allocRootEvent(carrot->getUUID()));
+                _network->pushOutEvent(RootEvent::allocRootEvent(carrot->getUUID(), plantingSpot->getPlantingID()));
             }
         }
     }
     
-    if(_input->didUnroot() && _map->getCharacter()->getUUID() != _map->getFarmers().at(0)->getUUID()){
+    if(_input->didUnroot() && _map->getCharacter()->getUUID() != _map->getFarmers().at(0)->getUUID() && plantingSpot != nullptr && plantingSpot->getCarrotPlanted()){
         auto currPos = _map->getCharacter()->getPosition();
         std::shared_ptr<Carrot> closestCarrot = nullptr;
         for (auto carrot : _map->getCarrots()){
@@ -108,7 +116,7 @@ void ActionController::preUpdate(float dt) {
             }
         }
         if(closestCarrot != nullptr && currPos.distance(closestCarrot->getPosition()) < 1.0){
-            _network->pushOutEvent(UnrootEvent::allocUnrootEvent(closestCarrot->getUUID()));
+            _network->pushOutEvent(UnrootEvent::allocUnrootEvent(closestCarrot->getUUID(), plantingSpot->getPlantingID()));
         }
     }
 }
@@ -180,12 +188,22 @@ void ActionController::processRootEvent(const std::shared_ptr<RootEvent>& event)
             carrot->gotRooted();
         }
     }
+    for(auto ps : _map->getPlantingSpots()){
+        if(ps->getPlantingID() == event->getPlantingSpotID()){
+            ps->setCarrotPlanted(true);
+        }
+    }
 }
 
 void ActionController::processUnrootEvent(const std::shared_ptr<UnrootEvent>& event){
     for(auto carrot : _map->getCarrots()){
         if(carrot->getUUID() == event->getUUID()){
             carrot->gotUnrooted();
+        }
+    }
+    for(auto ps : _map->getPlantingSpots()){
+        if(ps->getPlantingID() == event->getPlantingSpotID()){
+            ps->setCarrotPlanted(false);
         }
     }
 }

--- a/source/controllers/ActionController.cpp
+++ b/source/controllers/ActionController.cpp
@@ -109,7 +109,6 @@ void ActionController::preUpdate(float dt) {
         }
         if(closestCarrot != nullptr && currPos.distance(closestCarrot->getPosition()) < 1.0){
             _network->pushOutEvent(UnrootEvent::allocUnrootEvent(closestCarrot->getUUID()));
-            closestCarrot->gotUnrooted();
         }
     }
 }

--- a/source/controllers/CollisionController.cpp
+++ b/source/controllers/CollisionController.cpp
@@ -80,16 +80,10 @@ void CollisionController::beginContact(b2Contact* contact) {
             }
             if(name2 == "carrot") {
                 Carrot* carrot = dynamic_cast<Carrot*>(bd2);
-//                std::cout<<"carrot sensor status: "<< carrot->isSensor() << "\n";
                 if(farmer->isDashing() && !carrot->isCaptured() && !carrot->isRooted()){
                     _network->pushOutEvent(CaptureEvent::allocCaptureEvent(carrot->getUUID()));
                     carrot->gotCaptured();
                     farmer->grabCarrot();
-//                    std::shared_ptr<cugl::physics2::DistanceJoint> joint = std::make_shared<cugl::physics2::DistanceJoint>();
-//                    std::shared_ptr<physics2::Obstacle> ptr1(bd1);
-//                    std::shared_ptr<physics2::Obstacle> ptr2(bd2);
-//                    joint->initWithObstacles(ptr1, ptr2, Vec2(0,0), Vec2(0,0));
-//                    CULog("joint created");
                 }
             }
             if(name2 == "planting spot") {

--- a/source/controllers/CollisionController.cpp
+++ b/source/controllers/CollisionController.cpp
@@ -59,6 +59,10 @@ void CollisionController::beginContact(b2Contact* contact) {
                     _network->pushOutEvent(CaptureBarrotEvent::allocCaptureBarrotEvent(carrot->getUUID(), b2babycarrot->getID()));
                 }
             }
+            if(name2 == "planting spot" && _map->getCharacter()->getUUID() == carrot->getUUID()) {
+                PlantingSpot* plantingSpot = dynamic_cast<PlantingSpot*>(bd2);
+                plantingSpot->setBelowAvatar(true);
+            }
         }
         
         if (name1 == "baby") {
@@ -86,8 +90,10 @@ void CollisionController::beginContact(b2Contact* contact) {
                     farmer->grabCarrot();
                 }
             }
-            if(name2 == "planting spot") {
+            if(name2 == "planting spot" && _map->getCharacter()->getUUID() == farmer->getUUID()) {
+                PlantingSpot* plantingSpot = dynamic_cast<PlantingSpot*>(bd2);
                 farmer->setCanPlant(true);
+                plantingSpot->setBelowAvatar(true);
             }
         }
 
@@ -133,15 +139,20 @@ void CollisionController::endContact(b2Contact* contact) {
         std::string name2 = bd2->getName();
         
         if (name1 == "carrot") {
+            Carrot* carrot = dynamic_cast<Carrot*>(bd1);
             if (name2 == "wheat") {
                 Wheat* wheat = dynamic_cast<Wheat*>(bd2);
-                Carrot* carrot = dynamic_cast<Carrot*>(bd1);
                 wheat->setOccupied(false);
                 carrot->changeWheatContacts(-1);
             }
             
             if (name2 == "baby") {
             }
+            if(name2 == "planting spot" && _map->getCharacter()->getUUID() == carrot->getUUID()){
+                PlantingSpot* plantingSpot = dynamic_cast<PlantingSpot*>(bd2);
+                plantingSpot->setBelowAvatar(false);
+            }
+            
         }
         
         if (name1 == "baby") {
@@ -152,15 +163,16 @@ void CollisionController::endContact(b2Contact* contact) {
         }
         
         if (name1 == "farmer") {
+            Farmer* farmer = dynamic_cast<Farmer*>(bd1);
             if (name2 == "wheat") {
                 Wheat* wheat = dynamic_cast<Wheat*>(bd2);
-                Farmer* farmer = dynamic_cast<Farmer*>(bd1);
                 wheat->setOccupied(false);
                 farmer->changeWheatContacts(-1);
             }
-            if(name2 == "planting spot"){
-                Farmer* farmer = dynamic_cast<Farmer*>(bd1);
+            if(name2 == "planting spot" && _map->getCharacter()->getUUID() == farmer->getUUID()){
+                PlantingSpot* plantingSpot = dynamic_cast<PlantingSpot*>(bd2);
                 farmer->setCanPlant(false);
+                plantingSpot->setBelowAvatar(false);
             }
         }
         

--- a/source/events/RootEvent.cpp
+++ b/source/events/RootEvent.cpp
@@ -18,11 +18,12 @@ std::shared_ptr<NetEvent> RootEvent::newEvent(){
     return std::make_shared<RootEvent>();
 }
 
-std::shared_ptr<NetEvent> RootEvent::allocRootEvent(std::string uuid){
+std::shared_ptr<NetEvent> RootEvent::allocRootEvent(std::string uuid, int plantingspotid){
     //TODO: make a new shared copy of the event and set its _pos to pos.
 #pragma mark BEGIN SOLUTION
     auto event = std::make_shared<RootEvent>();
     event->_uuid = uuid;
+    event->_plantingspotid = plantingspotid;
     return event;
 #pragma mark END SOLUTION
 }
@@ -35,6 +36,7 @@ std::vector<std::byte> RootEvent::serialize(){
 #pragma mark BEGIN SOLUTION
     _serializer.reset();
     _serializer.writeString(_uuid);
+    _serializer.writeSint32(_plantingspotid);
     return _serializer.serialize();
 #pragma mark END SOLUTION
 }
@@ -56,5 +58,7 @@ void RootEvent::deserialize(const std::vector<std::byte>& data){
     _deserializer.receive(data);
     std::string uuid = _deserializer.readString();
     _uuid = uuid;
+    int plantingspotid = _deserializer.readSint32();
+    _plantingspotid = plantingspotid;
 #pragma mark END SOLUTION
 }

--- a/source/events/RootEvent.h
+++ b/source/events/RootEvent.h
@@ -20,6 +20,7 @@ protected:
     NetcodeDeserializer _deserializer;
     
     std::string _uuid;
+    int _plantingspotid;
     
 public:
     /**
@@ -31,7 +32,7 @@ public:
     */
    std::shared_ptr<NetEvent> newEvent() override;
     
-    static std::shared_ptr<NetEvent> allocRootEvent(std::string uuid);
+    static std::shared_ptr<NetEvent> allocRootEvent(std::string uuid, int plantingspotid);
     
     /**
      * Serialize any parameter that the event contains to a vector of bytes.
@@ -48,7 +49,11 @@ public:
      */
     void deserialize(const std::vector<std::byte>& data) override;
     
+    /** Gets the uuid of carrot  associated with the event */
     std::string getUUID() { return _uuid; }
+    
+    /** Gets the uuid of planting spot associated with the event */
+    int getPlantingSpotID() { return _plantingspotid; }
 };
 
 #endif /* RootEvent_h */

--- a/source/events/UnrootEvent.cpp
+++ b/source/events/UnrootEvent.cpp
@@ -18,10 +18,11 @@ std::shared_ptr<NetEvent> UnrootEvent::newEvent(){
     return std::make_shared<UnrootEvent>();
 }
 
-std::shared_ptr<NetEvent> UnrootEvent::allocUnrootEvent(std::string uuid){
+std::shared_ptr<NetEvent> UnrootEvent::allocUnrootEvent(std::string uuid, int plantingspotid){
 #pragma mark BEGIN SOLUTION
     auto event = std::make_shared<UnrootEvent>();
     event->_uuid = uuid;
+    event->_plantingspotid = plantingspotid;
     return event;
 #pragma mark END SOLUTION
 }
@@ -34,6 +35,7 @@ std::vector<std::byte> UnrootEvent::serialize(){
 #pragma mark BEGIN SOLUTION
     _serializer.reset();
     _serializer.writeString(_uuid);
+    _serializer.writeSint32(_plantingspotid);
     return _serializer.serialize();
 #pragma mark END SOLUTION
 }
@@ -52,6 +54,8 @@ void UnrootEvent::deserialize(const std::vector<std::byte>& data){
     _deserializer.receive(data);
     std::string uuid = _deserializer.readString();
     _uuid = uuid;
+    int plantingspotid = _deserializer.readSint32();
+    _plantingspotid = plantingspotid;
 #pragma mark END SOLUTION
 }
 

--- a/source/events/UnrootEvent.h
+++ b/source/events/UnrootEvent.h
@@ -19,6 +19,8 @@ protected:
     NetcodeDeserializer _deserializer;
     
     std::string _uuid;
+    int _plantingspotid;
+    
 public:
     /**
     * This method is used by the NetEventController to create a new event of using a
@@ -29,7 +31,7 @@ public:
     */
    std::shared_ptr<NetEvent> newEvent() override;
     
-    static std::shared_ptr<NetEvent> allocUnrootEvent(std::string uuid);
+    static std::shared_ptr<NetEvent> allocUnrootEvent(std::string uuid, int plantingspotid);
     
     /**
      * Serialize any parameter that the event contains to a vector of bytes.
@@ -48,6 +50,9 @@ public:
     
     /** Gets the uuid of rooted carrot associated with the event. */
     std::string getUUID() { return _uuid; }
+    
+    /** Gets the uuid of planting spot associated with the event */
+    int getPlantingSpotID() { return _plantingspotid; }
 };
 
 #endif /* UnrootEvent_h */

--- a/source/objects/Map.cpp
+++ b/source/objects/Map.cpp
@@ -436,6 +436,7 @@ void Map::loadPlantingSpot(float x, float y, float width, float height) {
     std::shared_ptr<PlantingSpot> plantingSpot = PlantingSpot::alloc(spotPos, {width, height}, _scale.x);
     plantingSpot->setDebugColor(DEBUG_COLOR);
     plantingSpot->setName("planting spot");
+    plantingSpot->setPlantingID(_plantingSpot.size());
     _plantingSpot.push_back(plantingSpot);
 
     auto spotNode = scene2::PolygonNode::allocWithTexture(_assets->get<Texture>(PLANTING_SPOT_TEXTURE));

--- a/source/objects/PlantingSpot.h
+++ b/source/objects/PlantingSpot.h
@@ -16,8 +16,13 @@ class PlantingSpot : public cugl::physics2::BoxObstacle {
 private:
     /** The scale between the physics world and the screen (MUST BE UNIFORM) */
     float _drawScale;
+    /** Whether a carrot is planted here */
+    bool _isCarrotPlanted;
+    
+protected:
     /** The scene graph node for the planting spot. */
     std::shared_ptr<cugl::scene2::PolygonNode> _node;
+    
 public:
     /**
      * Creates a degenerate planting spot object.
@@ -83,7 +88,11 @@ public:
      *
      * @return the scene graph node representing this PlantingSpot.
      */
-    const std::shared_ptr<cugl::scene2::SceneNode>& getSceneNode() const { return _node; }
+    const std::shared_ptr<cugl::scene2::PolygonNode>& getSceneNode() const { return _node; }
+    
+    bool getCarrotPlanted() { return _isCarrotPlanted; }
+    
+    void setCarrotPlanted(bool b) { _isCarrotPlanted = b; }
 
 };
 #endif /* PlantingSpot_h */

--- a/source/objects/PlantingSpot.h
+++ b/source/objects/PlantingSpot.h
@@ -18,6 +18,10 @@ private:
     float _drawScale;
     /** Whether a carrot is planted here */
     bool _isCarrotPlanted;
+    /** Whether an avatar is on it */
+    bool _belowAvatar;
+    /** ID of this planting spot*/
+    int _plantingID;
     
 protected:
     /** The scene graph node for the planting spot. */
@@ -93,6 +97,14 @@ public:
     bool getCarrotPlanted() { return _isCarrotPlanted; }
     
     void setCarrotPlanted(bool b) { _isCarrotPlanted = b; }
+    
+    bool getBelowAvatar() { return _belowAvatar; }
+    
+    void setBelowAvatar(bool b) { _belowAvatar = b; }
+    
+    int getPlantingID() { return _plantingID; }
+    
+    void setPlantingID(int plantingID) { _plantingID = plantingID; }
 
 };
 #endif /* PlantingSpot_h */


### PR DESCRIPTION
-planting spots can recognize when a character is running over it
-planting spots can recognize when a carrot is planted in it
-max one rooted carrot per planting spot
-update root/unroot events